### PR TITLE
Library update

### DIFF
--- a/Labs/Lab3_LinearRegression/Lab3_LinearRegression_Final_solns.ipynb
+++ b/Labs/Lab3_LinearRegression/Lab3_LinearRegression_Final_solns.ipynb
@@ -763,7 +763,7 @@
    "outputs": [],
    "source": [
     "#split into training set and testing set\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "#set random_state to get the same split every time\n",
     "traindf, testdf = train_test_split(dfcars, test_size=0.3, random_state=6)"
    ]


### PR DESCRIPTION
Scikit-learn's `cross_validation` is now deprecated in favor of ` model_selection`.